### PR TITLE
Fix deb stretch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ add_definitions(${PCL_DEFINITIONS})
 find_package(MRPT 1.5 REQUIRED obs graphs maps slam)
 message(STATUS "MRPT_VERSION: ${MRPT_VERSION}")
 
+# Debian Stretch doesn't properly find the recursive Qt5Widgets dependency from
+# PCL io.  We force find it here so that cmake is happy.
+find_package(Qt5Widgets REQUIRED)
+
 if (CMAKE_COMPILER_IS_GNUCXX)
 	# High level of warnings.
 	# The -Wno-long-long is required in 64bit systems when including sytem headers.

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,9 @@
   <exec_depend>message_runtime</exec_depend>
   <build_depend>pcl_conversions</build_depend> <!-- Only during BUILD: for unit tests -->
   <build_depend>libpcl-all-dev</build_depend> <!-- Only during BUILD: for unit tests -->
+  <!-- Workaround for Debian Stretch not importing qtbase5-dev by itself;
+       only necessary during binary BUILD for the unit tests. -->
+  <build_depend>qtbase5-dev</build_depend>
 
   <!-- Use buildtool_depend for build tool packages: -->
   <buildtool_depend>catkin</buildtool_depend>

--- a/src/test/test_map.cpp
+++ b/src/test/test_map.cpp
@@ -49,9 +49,9 @@ TEST(Map, basicTestHeader)
 	EXPECT_EQ(srcRos.info.width, desMrpt.getSizeX());
 	EXPECT_EQ(srcRos.info.height, desMrpt.getSizeY());
 	EXPECT_EQ(srcRos.info.resolution, desMrpt.getResolution());
-	for (int h = 0; h < srcRos.info.width; h++)
+	for (uint32_t h = 0; h < srcRos.info.width; h++)
 	{
-		for (int w = 0; w < srcRos.info.width; w++)
+		for (uint32_t w = 0; w < srcRos.info.width; w++)
 		{
 			EXPECT_EQ(
 				desMrpt.getPos(w, h), 0.5);  // all -1 entreis should map to 0.5
@@ -69,9 +69,9 @@ TEST(Map, check_ros2mrpt_and_back)
 
 	ASSERT_TRUE(mrpt_bridge::convert(srcRos, desMrpt));
 	ASSERT_TRUE(mrpt_bridge::convert(desMrpt, desRos, desRos.header));
-	for (int h = 0; h < srcRos.info.width; h++)
+	for (uint32_t h = 0; h < srcRos.info.width; h++)
 	{
-		for (int w = 0; w < srcRos.info.width; w++)
+		for (uint32_t w = 0; w < srcRos.info.width; w++)
 		{
 			EXPECT_EQ(
 				desRos.data[h * srcRos.info.width + h],


### PR DESCRIPTION
There are 2 commits in here:

1.  The first one makes it so things should compile properly on Debian Stretch, by force adding a Qt5Widgets dependency.
1.  The second one cleans up some build warnings while I was in here.