### PR TITLE
Quaternion singularity

### DIFF
--- a/src/test/test_pose.cpp
+++ b/src/test/test_pose.cpp
@@ -162,6 +162,9 @@ TEST(PoseConversions, check_CPose3D_tofrom_ROS)
 	check_CPose3D_tofrom_ROS(1, 2, 3, DEG2RAD(0), DEG2RAD(0), DEG2RAD(30));
 
 	check_CPose3D_tofrom_ROS(1, 2, 3, DEG2RAD(-5), DEG2RAD(15), DEG2RAD(-30));
+	
+	check_CPose3D_tofrom_ROS(0, 0, 0, DEG2RAD(0), DEG2RAD(90), DEG2RAD(0));
+	check_CPose3D_tofrom_ROS(0, 0, 0, DEG2RAD(0), DEG2RAD(-90), DEG2RAD(0));
 }
 
 // Declare a test


### PR DESCRIPTION
Check for degenerate case when converting quaternion to angles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrpt-ros-pkg/mrpt_bridge/8)
<!-- Reviewable:end -->
