### PR TITLE
Fixed build error for ubuntu 20.04, ros-noetic in imu.cpp

### DIFF
--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -50,7 +50,7 @@ bool imu::mrpt2ros(
 {
 	msg.header = msg_header;
 
-	vector<double> measurements = obj.rawMeasurements;
+	auto measurements = obj.rawMeasurements;
 	msg.orientation.x = measurements.at(IMU_ORI_QUAT_X);
 	msg.orientation.y = measurements.at(IMU_ORI_QUAT_Y);
 	msg.orientation.z = measurements.at(IMU_ORI_QUAT_Z);


### PR DESCRIPTION
`mrpt_bridge/src/imu.cpp:53:36: error: conversion from ‘const std::array<double, 31>’ to non-scalar type ‘std::vector<double, std::allocator<double> >’ requested
   53 |  vector<double> measurements = obj.rawMeasurements;
`
This was likely due to a change in the ```CObservationIMU.h``` file in `libmrpt_dev v1:2.4.0`. Arrays are used instead of vectors. So basically changed the type of `measurements` to ```auto``` as the type can be deduced. 