### PR TITLE
Set default log4cxx level

### DIFF
--- a/include/mrpt_bridge/utils.h
+++ b/include/mrpt_bridge/utils.h
@@ -61,7 +61,8 @@ inline VerbosityLevel rosLoggerLvlToMRPTLoggerLvl(log4cxx::LevelPtr lvl)
 	}
 	else
 	{
-		THROW_EXCEPTION("Unknown log4cxx::Level is given.");
+		mrpt_lvl = LVL_INFO;
+		ROS_ERROR("Unknown log4cxx::Level is given.");
 	}
 
 	return mrpt_lvl;


### PR DESCRIPTION
Throwing an exception when there is no default log4cxx::Level makes it impossible to diagnose anything for users that are not familiar with log4cxx. A "ROS_ERROR" is preferable in my opinion.

Alternatively, there could be an exception/ROS_ERROR with a detailed message about how to set a log4cxx level. I just don't know how to myself ^^"

Fixes #13 